### PR TITLE
Use <C-w> instead of <C-\\><C-n> in terminal maps

### DIFF
--- a/plugin/miniterm.vim
+++ b/plugin/miniterm.vim
@@ -11,7 +11,7 @@ g:miniterm_dont_map = get(g:, "miniterm_dont_map", false)
 # Helper to map in normal and terminal mode
 def TerminalMap(map: string, com: string)
     execute $"nnoremap <silent> {map} {com}"
-    execute $"tnoremap <silent> {map} <C-\\><C-n>{com}"
+    execute $"tnoremap <silent> {map} <C-w>{com}"
 enddef
 
 command! MinitermToggle       miniterm.GetManager().ToggleTerminal()


### PR DESCRIPTION
Hi,
This make so that when you toggle the terminal you will go back in insert mode immediately. Without every time press 'i' to type again.